### PR TITLE
fix(Position): simplifies calculation of top position

### DIFF
--- a/src/example/index.js
+++ b/src/example/index.js
@@ -8,6 +8,7 @@ import ParallaxComponent from '../';
 import styles from './styles';
 
 const WORD = 'AWESOME REACT';
+const random = (min, max) => Math.random() * (max - min) + min;
 
 export default class ExamplePage extends Component {
   render() {
@@ -22,7 +23,7 @@ export default class ExamplePage extends Component {
 
       {
         WORD.split('').map((letter, index) =>
-          <ParallaxComponent speed={Math.floor(Math.random() * (2 - 0) + 0) === 1 ? 0 : Math.random() * (0.1 - 0) + 0}
+          <ParallaxComponent speed={random(0, 0.1) * ((random(0, 2) > 1) ? 1 : -1)}
                              top="40%"
                              left={(index + 1) * 80}
                              key={index}>

--- a/src/example/index.js
+++ b/src/example/index.js
@@ -22,7 +22,7 @@ export default class ExamplePage extends Component {
 
       {
         WORD.split('').map((letter, index) =>
-          <ParallaxComponent speed={Math.floor(Math.random() * (2 - 0) + 0) === 1 ? '-' : '' + Math.random() * (0.1 - 0) + 0}
+          <ParallaxComponent speed={Math.floor(Math.random() * (2 - 0) + 0) === 1 ? 0 : Math.random() * (0.1 - 0) + 0}
                              top="40%"
                              left={(index + 1) * 80}
                              key={index}>

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export default class ParallaxComponent extends Component {
 
     // Top positons
     const pageTop = window.pageYOffset;
-    const newTop = (top - (pageTop * speed)).toFixed(0);
+    const newTop = (top - (pageTop * speed));
 
     // Set new top position
     this.refs.parallaxElement.style.top = `${newTop}px`;

--- a/src/index.js
+++ b/src/index.js
@@ -55,8 +55,7 @@ export default class ParallaxComponent extends Component {
 
     // Top positons
     const pageTop = window.pageYOffset;
-    const elemTop = this.refs.parallaxElement.offsetTop;
-    const newTop = (((pageTop - elemTop) * (+speed * -1)) + top).toFixed(0);
+    const newTop = (top - (pageTop * speed)).toFixed(0);
 
     // Set new top position
     this.refs.parallaxElement.style.top = `${newTop}px`;

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export default class ParallaxComponent extends Component {
 
   static propTypes = {
     children: React.PropTypes.object,
-    speed: React.PropTypes.string,
+    speed: React.PropTypes.number,
 
     // Style
     width: React.PropTypes.string,
@@ -23,7 +23,7 @@ export default class ParallaxComponent extends Component {
     top: 'inherit',
     left: 'inherit',
     right: 'inherit',
-    speed: '-0.03',
+    speed: -0.03,
   }
 
   constructor(props) {

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export default class ParallaxComponent extends Component {
 
     return top.indexOf('%') > -1
       ? window.innerHeight * (top.replace('%', '') / 100)
-      : +top;
+      : parseInt(top, 10);
   }
 
   handleScroll() {


### PR DESCRIPTION
Hi !

I have found your React component and it is pretty cool !

However, I think it's be possible to simplifie many thing whose the top position calculation.

For now, between the initial position and the first scroll event, you have a first uncontrolled gap. This seems to be because of the `elemTop` variable initially different to the top value.

I propose this calculation who simply make the difference between the initial top position and the scroll move braked by the `speed`. 

The effect is exactly the same and the gap is deleted. 

Have a nice day !
